### PR TITLE
ACPENG 3106: Remediate CVEs and include push_to_ECR

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ steps:
       cpu: 1000
       memory: 1024Mi
   environment:
-    IMAGE_NAME: acp-opensearch-alias-exporter:latest
+    IMAGE_NAME: acp-multipage-example-app:$${DRONE_COMMIT_SHA}
     IGNORE_UNFIXED: "true"
     FAIL_ON_DETECTION: "true"
   when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,6 @@ steps:
   - docker build -t "acp-multipage-example-app:${DRONE_COMMIT_SHA}" . --no-cache
   when:
     event:
-    - push
     - pull_request
     - tag
 
@@ -35,9 +34,8 @@ steps:
   when:
     event:    
     - pull_request
-    - push
 
-- name: push_to_ecr
+- name: push_tag_to_ecr
   image: plugins/ecr
   pull: if-not-exists
   settings:
@@ -55,27 +53,7 @@ steps:
     event: 
     - tag
 
-- name: push_artifactory_latest
-  pull: if-not-exists
-  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-  commands:
-  - docker login -u=$${ARTIFACTORY_USERNAME} -p=$${ARTIFACTORY_PASSWORD} docker.digital.homeoffice.gov.uk
-  - docker tag acp-multipage-example-app:$${DRONE_COMMIT_SHA} docker.digital.homeoffice.gov.uk/acp-multipage-example-app:latest
-  - docker tag acp-multipage-example-app:$${DRONE_COMMIT_SHA} docker.digital.homeoffice.gov.uk/acp-multipage-example-app:$${DRONE_COMMIT_SHA}
-  - docker push docker.digital.homeoffice.gov.uk/acp-multipage-example-app:latest
-  - docker push docker.digital.homeoffice.gov.uk/acp-multipage-example-app:$${DRONE_COMMIT_SHA}
-  environment:
-    ARTIFACTORY_PASSWORD:
-      from_secret: artifactory_password
-    ARTIFACTORY_USERNAME:
-      from_secret: artifactory_username
-  when:
-    branch:
-    - master
-    event:
-    - push
-
-- name: push_artifactory_tag
+- name: push_tag_to_artifactory
   pull: if-not-exists
   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
   commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,16 +21,21 @@ steps:
     - pull_request
     - tag
 
-- name: scan-image
-  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
-  pull: always
+- name: trivy_sast
+  pull: Always
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+  resources:
+    limits:
+      cpu: 1000
+      memory: 1024Mi
   environment:
-    IMAGE_NAME:  acp-multipage-example-app:${DRONE_COMMIT_SHA}
-    WHITELIST: CVE-2008-4318,CVE-2020-25613,CVE-2021-28965,CVE-2021-3517
+    IMAGE_NAME: acp-opensearch-alias-exporter:latest
+    IGNORE_UNFIXED: "true"
+    FAIL_ON_DETECTION: "true"
   when:
-    event:
-    - push
+    event:    
     - pull_request
+    - push
 
 - name: push_to_ecr
   image: plugins/ecr
@@ -89,9 +94,3 @@ steps:
 services:
 - name: docker
   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-
-- name: anchore-submission-server
-  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
-  pull: always
-  commands:
-    - /run.sh server

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
   commands:
   # wait for docker service to be up before running docker build
   - /usr/local/bin/wait
-  - docker build -t  acp-multipage-example-app:$${DRONE_COMMIT_SHA} . --no-cache
+  - docker build -t "acp-multipage-example-app:${DRONE_COMMIT_SHA}" . --no-cache
   when:
     event:
     - push
@@ -29,7 +29,7 @@ steps:
       cpu: 1000
       memory: 1024Mi
   environment:
-    IMAGE_NAME: acp-multipage-example-app:$${DRONE_COMMIT_SHA}
+    IMAGE_NAME: "acp-multipage-example-app:${DRONE_COMMIT_SHA}"
     IGNORE_UNFIXED: "true"
     FAIL_ON_DETECTION: "true"
   when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
   commands:
   # wait for docker service to be up before running docker build
-  - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
+  - /usr/local/bin/wait
   - docker build -t  acp-multipage-example-app:$${DRONE_COMMIT_SHA} . --no-cache
   when:
     event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,6 +18,7 @@ steps:
   when:
     event:
     - push
+    - pull_request
     - tag
 
 - name: scan-image
@@ -29,6 +30,24 @@ steps:
   when:
     event:
     - push
+    - pull_request
+
+- name: push_to_ecr
+  image: plugins/ecr
+  pull: if-not-exists
+  settings:
+    registry: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
+    repo: acp/multipage-example-app
+    tags:
+    - "${DRONE_TAG}"  
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+    AWS_REGION: eu-west-2
+  when:
+    event: 
     - tag
 
 - name: push_artifactory_latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.19.10-alpine
+FROM nginx:1.30.2-alpine
 
 RUN apk upgrade --no-cache
 
@@ -17,3 +17,4 @@ RUN touch /var/run/nginx.pid && \
 USER 1000
 
 EXPOSE 3000
+`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-FROM nginx:1.19.2-alpine
-RUN addgroup -S app \
-        && adduser -S -g app -u 1000 app
-COPY ./default.conf /etc/nginx/conf.d
-COPY ./webpages/ /usr/share/nginx/html
-RUN chown -R 1000:1000 /usr/share/nginx && \
-        chown -R 1000:1000 /var/cache/nginx && \
-        chown -R 1000:1000 /var/log/nginx && \
-        chown -R 1000:1000 /etc/nginx/conf.d
+FROM nginx:1.19.10-alpine
+
+RUN apk upgrade --no-cache
+
+RUN addgroup -S app && \
+        adduser -S -g app -u 1000 app
+
+COPY --chown=1000:1000 ./default.conf /etc/nginx/conf.d
+
+COPY --chown=1000:1000 ./webpages/ /usr/share/nginx/html
+
+RUN chown -R 1000:1000 /usr/share/nginx /var/cache/nginx /var/log/nginx 
+
 RUN touch /var/run/nginx.pid && \
         chown -R 1000:1000 /var/run/nginx.pid
+
 USER 1000
+
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,3 @@ RUN touch /var/run/nginx.pid && \
 USER 1000
 
 EXPOSE 3000
-`


### PR DESCRIPTION
[ACPENG-3106](https://collaboration.homeoffice.gov.uk/jira/browse/ACPENG-3106)

This PR:
- remediates CVEs in the Docker image by updating to more recent minor versions of alpine and nginx
- adds a push_tag_ot_ecr step to the Drone pipeline
- removes the push_latest_to_artifactory step.

```
Report Summary

┌──────────────────────────────────┬────────┬─────────────────┬─────────┐
│              Target              │  Type  │ Vulnerabilities │ Secrets │
├──────────────────────────────────┼────────┼─────────────────┼─────────┤
│ multipage-latest (alpine 3.13.5) │ alpine │        0        │    -    │
└──────────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```
The updated image has been run locally and performs as expected.